### PR TITLE
Use composer update instead of install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         run: sudo apt update && sudo apt install libxml2-utils
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: composer update --prefer-dist --no-progress
 
       - name: PHPUnit configuration file
         run: xmllint --schema vendor/phpunit/phpunit/phpunit.xsd --noout phpunit.xml.dist
@@ -88,7 +88,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: composer update --prefer-dist --no-progress
 
       - name: Coding Guideline
         run: ./vendor/bin/php-cs-fixer fix --dry-run --diff

--- a/shell.nix
+++ b/shell.nix
@@ -24,7 +24,7 @@ let
       composer
     ];
     text = ''
-      composer install --prefer-dist --no-progress --working-dir="$PROJECT_ROOT"
+      composer update --prefer-dist --no-progress
     '';
   };
   projectCgl = pkgs.writeShellApplication {


### PR DESCRIPTION
There is no composer.lock within the project. Composer would raise a notice when using composer install without a lock file.