### PR TITLE
Support MM Relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.3.1 - 2023-08-10
+
+### Added
+
+- Add Support for mm relations in assertions.
+
 ## v1.3.0 - 2023-05-11
 
 ### Added

--- a/Classes/TestingFramework.php
+++ b/Classes/TestingFramework.php
@@ -54,7 +54,7 @@ trait TestingFramework
         $failMessages = [];
 
         foreach ($dataSet as $tableName => $expectedRecords) {
-            $records = $this->getAllRecords($tableName, true);
+            $records = $this->getAllRecords($tableName, (isset($GLOBALS['TCA'][$tableName])));
 
             foreach ($expectedRecords as $assertion) {
                 $result = $this->assertInRecords($assertion, $records);

--- a/Tests/Functional/AssertTest.php
+++ b/Tests/Functional/AssertTest.php
@@ -63,6 +63,15 @@ class AssertTest extends AbstractFunctionalTestCase
     /**
      * @test
      */
+    public function canAssertMmRelation(): void
+    {
+        $this->importPHPDataSet(__DIR__ . '/Fixtures/MmRelation.php');
+        $this->assertPHPDataSet(__DIR__ . '/Fixtures/MmRelation.php');
+    }
+
+    /**
+     * @test
+     */
     public function failsForMissingAssertionWithUid(): void
     {
         $this->expectException(AssertionFailedError::class);
@@ -78,14 +87,11 @@ class AssertTest extends AbstractFunctionalTestCase
         $this->importPHPDataSet(__DIR__ . '/Fixtures/SimpleSet.php');
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage(
-            'Assertion in data-set failed for "pages:1":'
-            . PHP_EOL
-            . 'Fields|Assertion             |Record  '
-            . PHP_EOL
-            . 'title |Rootpage without match|Rootpage'
-            . PHP_EOL
-        );
+        $this->expectExceptionMessage(implode(PHP_EOL, [
+            'Assertion in data-set failed for "pages:1":',
+            'Fields|Assertion             |Record  ',
+            'title |Rootpage without match|Rootpage',
+        ]));
         $this->assertPHPDataSet(__DIR__ . '/Fixtures/AssertDifferingWithUid.php');
     }
 
@@ -103,8 +109,33 @@ class AssertTest extends AbstractFunctionalTestCase
             '   \'pid\' => \'0\', ',
             '   \'title\' => \'Rootpage without match\'',
             ')',
-        ]) . PHP_EOL);
+            '',
+        ]));
         $this->assertPHPDataSet(__DIR__ . '/Fixtures/AssertDifferingWithoutUid.php');
+    }
+
+    /**
+     * @test
+     */
+    public function failsForAssertionForMmRelation(): void
+    {
+        $this->importPHPDataSet(__DIR__ . '/Fixtures/MmRelation.php');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(implode(PHP_EOL, [
+            'Assertion in data-set failed for "sys_category_record_mm":',
+            'array(',
+            '   \'uid_local\' => \'1\', ',
+            '   \'uid_foreign\' => \'2\', ',
+            '   \'tablenames\' => \'pages\', ',
+            '   \'fieldname\' => \'categories\', ',
+            '   \'sorting\' => \'0\', ',
+            '   \'sorting_foreign\' => \'3\'',
+            ')',
+            '',
+            'Not asserted record found for "sys_category_record_mm:".',
+        ]));
+        $this->assertPHPDataSet(__DIR__ . '/Fixtures/MmRelationBroken.php');
     }
 
     /**

--- a/Tests/Functional/Fixtures/MmRelation.php
+++ b/Tests/Functional/Fixtures/MmRelation.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'sys_category_record_mm' => [
+        [
+            'uid_local' => 1,
+            'uid_foreign' => 1,
+            'tablenames' => 'pages',
+            'fieldname' => 'categories',
+            'sorting' => 0,
+            'sorting_foreign' => 1,
+        ],
+        // A single one would work.
+        // But a 2nd would have the same internal index, an empty key.
+        [
+            'uid_local' => 1,
+            'uid_foreign' => 2,
+            'tablenames' => 'pages',
+            'fieldname' => 'categories',
+            'sorting' => 0,
+            'sorting_foreign' => 2,
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/MmRelationBroken.php
+++ b/Tests/Functional/Fixtures/MmRelationBroken.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'sys_category_record_mm' => [
+        [
+            'uid_local' => 1,
+            'uid_foreign' => 1,
+            'tablenames' => 'pages',
+            'fieldname' => 'categories',
+            'sorting' => 0,
+            'sorting_foreign' => 1,
+        ],
+        // A single one would work.
+        // But a 2nd would have the same internal index, an empty key.
+        [
+            'uid_local' => 1,
+            'uid_foreign' => 2,
+            'tablenames' => 'pages',
+            'fieldname' => 'categories',
+            'sorting' => 0,
+            'sorting_foreign' => 3,
+        ],
+    ],
+];


### PR DESCRIPTION
Those don't have a hash or uid field.
We use a quick check whether a table is part of TCA in order to determine those tables.