### PR TITLE
Mark as dev dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add command `convert-from-csv`.
+- Mark as dev dependency.
 
 ## v1.3.1 - 2023-08-10
 

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,10 @@
     "description": "Enables usage of PHP data sets within TYPO3.",
     "type": "library",
     "license": "GPL-2.0-or-later",
+    "keywords": [
+        "dev",
+        "testing"
+    ],
     "autoload": {
         "psr-4": {
             "Codappix\\Typo3PhpDatasets\\": "Classes/"


### PR DESCRIPTION
That way composer will warn consumers if they require this package as none --dev.

Resolves: #9